### PR TITLE
Removing Subpath to avoid conflict with route

### DIFF
--- a/history/Training/index.html
+++ b/history/Training/index.html
@@ -6,22 +6,22 @@
 <body>
     <h1>Training Pages</h1>
     <ul>
-      <li><a href='/AccesstoSQLServerandNET.aspx.html'>history/Training/AccesstoSQLServerandNET.aspx.html</a></li>
-      <li><a href='/ALM.aspx.html'>history/Training/ALM.aspx.html</a></li>
-      <li><a href='/ALMCustomization.aspx.html'>history/Training/ALMCustomization.aspx.html</a></li>
-      <li><a href='/BI-TheGlory.aspx.html'>history/Training/BI-TheGlory.aspx.html</a></li>
-      <li><a href='/BI-TheGuts.aspx.html'>history/Training/BI-TheGuts.aspx.html</a></li>
-      <li><a href='/BusinessIntelligenceForBusiness.aspx.html'>history/Training/BusinessIntelligenceForBusiness.aspx.html</a></li>
-      <li><a href='/Expression.aspx.html'>history/Training/Expression.aspx.html</a></li>
-      <li><a href='/ProcessImprovementForSoftwareTeams.aspx.html'>history/Training/ProcessImprovementForSoftwareTeams.aspx.html</a></li>
-      <li><a href='/ReportingServices.aspx.html'>history/Training/ReportingServices.aspx.html</a></li>
-      <li><a href='/Sessions-Past.aspx.html'>history/Training/Sessions-Past.aspx.html</a></li>
-      <li><a href='/SharePoint.aspx.html'>history/Training/SharePoint.aspx.html</a></li>
-      <li><a href='/SharePointUTS.aspx.html'>history/Training/SharePointUTS.aspx.html</a></li>
-      <li><a href='/SQLBI.aspx.html'>history/Training/SQLBI.aspx.html</a></li>
-      <li><a href='/SQLServer.aspx.html'>history/Training/SQLServer.aspx.html</a></li>
-      <li><a href='/SQLServerBI.aspx.html'>history/Training/SQLServerBI.aspx.html</a></li>
-      <li><a href='/VisualStudio.aspx.html'>history/Training/VisualStudio.aspx.html</a></li>
+      <li><a href='/history/AccesstoSQLServerandNET.aspx.html'>history/Training/AccesstoSQLServerandNET.aspx.html</a></li>
+      <li><a href='/history/ALM.aspx.html'>history/Training/ALM.aspx.html</a></li>
+      <li><a href='/history/ALMCustomization.aspx.html'>history/Training/ALMCustomization.aspx.html</a></li>
+      <li><a href='/history/BI-TheGlory.aspx.html'>history/Training/BI-TheGlory.aspx.html</a></li>
+      <li><a href='/history/BI-TheGuts.aspx.html'>history/Training/BI-TheGuts.aspx.html</a></li>
+      <li><a href='/history/BusinessIntelligenceForBusiness.aspx.html'>history/Training/BusinessIntelligenceForBusiness.aspx.html</a></li>
+      <li><a href='/history/Expression.aspx.html'>history/Training/Expression.aspx.html</a></li>
+      <li><a href='/history/ProcessImprovementForSoftwareTeams.aspx.html'>history/Training/ProcessImprovementForSoftwareTeams.aspx.html</a></li>
+      <li><a href='/history/ReportingServices.aspx.html'>history/Training/ReportingServices.aspx.html</a></li>
+      <li><a href='/history/Sessions-Past.aspx.html'>history/Training/Sessions-Past.aspx.html</a></li>
+      <li><a href='/history/SharePoint.aspx.html'>history/Training/SharePoint.aspx.html</a></li>
+      <li><a href='/history/SharePointUTS.aspx.html'>history/Training/SharePointUTS.aspx.html</a></li>
+      <li><a href='/history/SQLBI.aspx.html'>history/Training/SQLBI.aspx.html</a></li>
+      <li><a href='/history/SQLServer.aspx.html'>history/Training/SQLServer.aspx.html</a></li>
+      <li><a href='/history/SQLServerBI.aspx.html'>history/Training/SQLServerBI.aspx.html</a></li>
+      <li><a href='/history/VisualStudio.aspx.html'>history/Training/VisualStudio.aspx.html</a></li>
 
     </ul>
 </body>


### PR DESCRIPTION
Azure Storage serves the `index.html` file under both `/history/Training` and `/history/Training/index.html`. On Front Door, we've configured it to treat `/history/Training` as the root folder for our route `/history`. Therefore, any page we want to serve under this route must start with `/history/{{ filename.html }}` on the storage account.