### PR TITLE
✨ added EmailMergePro default page to wayback machine list

### DIFF
--- a/html_archiver.py
+++ b/html_archiver.py
@@ -50,6 +50,7 @@ IMAGE_REPLACEMENTS: dict[str, str] = {
 PAGE_REPLACEMENTS: dict[str, str] = {
     "https://www.ssw.com.au/ssw/DataPRO/": "https://web.archive.org/web/20190322231649/https://www.ssw.com.au/ssw/DataPro/",
     "https://www.ssw.com.au/ssw/ExchangeReporter/Default.aspx": "https://web.archive.org/web/20190404105934/https://www.ssw.com.au/ssw/ExchangeReporter/Default.aspx",
+    "https://www.ssw.com.au/ssw/EmailMergePRO/Default.aspx": "https://web.archive.org/web/20190411004326/https://www.ssw.com.au/ssw/EmailMergePRO/Default.aspx"
 }
 
 PARENT_DIR = "history/"


### PR DESCRIPTION
### Descripion

'https://www.ssw.com.au/ssw/EmailMergePRO/Default.aspx' points to a 404 page so I updated the script to download the last available entry on the wayback machine instead

Relevant Issue
#31 