### PR TITLE
fixed banner link in developer central htm file

### DIFF
--- a/history/code-auditor/2407-developer-central-extra.htm
+++ b/history/code-auditor/2407-developer-central-extra.htm
@@ -30,8 +30,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
+                    <a href="https://codeauditor.com/" style="color: white">
+                        codeauditor.com
                     </a>
 </p>
 </div>


### PR DESCRIPTION
The this page is under the code-auditor directory so it should link to code auditor

Relevant Issue: [2581](https://github.com/SSWConsulting/SSW.Website/issues/2581)