### PR TITLE
Updated github action to sync files to blob storage instead of uploading

### DIFF
--- a/upload-blob.sh
+++ b/upload-blob.sh
@@ -1,4 +1,4 @@
-az storage blob upload-batch \
+az storage blob sync \
  --auth-mode key \
  --account-key "$ARCHIVE_KEY" \
  --destination "\$web" \


### PR DESCRIPTION
I'm running into the odd issue where a file gets checked into source control that shouldn't have been so I'm changing the shell file to sync the blob storage container to the repo's contents instead of uploading.