### PR TITLE
Fixed blob storage sync using incorrect parameters for sync

### DIFF
--- a/upload-blob.sh
+++ b/upload-blob.sh
@@ -1,8 +1,7 @@
+
 az storage blob sync \
- --auth-mode key \
- --account-key "$ARCHIVE_KEY" \
- --destination "\$web" \
- --account-name stsswwebsitezjkojq27uhqb \
- --destination-path history \
+ --container web \
  --source history \
- --overwrite \
+ --destination history \
+ --account-name stsswwebsitezjkojq27uhqb \
+ --account-key "$ARCHIVE_KEY" \


### PR DESCRIPTION
### Description

In a previous PR I updated the shell script that pushes the files to blob storage to sync changes instead of performing an upload batch. However the shell script now fails when the GitHub action runs. The issue appears to be that the parameters I provided in the azure CLI command are invalid, causing the upload to fail. 

In this branch I've updated the action with the correct commands.