### PR TITLE
Added missing archive banner to exchange-reporter pages

### DIFF
--- a/archive/exchange-reporter/reports/current-all-mailboxes-folder-l.htm
+++ b/archive/exchange-reporter/reports/current-all-mailboxes-folder-l.htm
@@ -1,1 +1,26 @@
-<img height="871" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder-l.gif" width="1026" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="871" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder-l.gif" width="1026"/>

--- a/archive/exchange-reporter/reports/current-all-mailboxes-folder.htm
+++ b/archive/exchange-reporter/reports/current-all-mailboxes-folder.htm
@@ -1,1 +1,26 @@
-<img height="940" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder.gif" width="1257" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="940" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder.gif" width="1257"/>

--- a/archive/exchange-reporter/reports/current-folder-tree-sizes-all.htm
+++ b/archive/exchange-reporter/reports/current-folder-tree-sizes-all.htm
@@ -1,1 +1,26 @@
-<img height="944" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-all.gif" width="975" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="944" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-all.gif" width="975"/>

--- a/archive/exchange-reporter/reports/current-folder-tree-sizes-owner.htm
+++ b/archive/exchange-reporter/reports/current-folder-tree-sizes-owner.htm
@@ -1,1 +1,26 @@
-<img height="896" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-owner.gif" width="1021" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="896" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-owner.gif" width="1021"/>

--- a/archive/exchange-reporter/reports/extraction-log-all-records.htm
+++ b/archive/exchange-reporter/reports/extraction-log-all-records.htm
@@ -1,1 +1,26 @@
-<img height="946" src="/archive/exchange-reporter/reports/images/extraction-log-all-records.gif" width="965" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="946" src="/archive/exchange-reporter/reports/images/extraction-log-all-records.gif" width="965"/>

--- a/archive/exchange-reporter/reports/extraction-log-last-extraction.htm
+++ b/archive/exchange-reporter/reports/extraction-log-last-extraction.htm
@@ -1,1 +1,26 @@
-<img height="948" src="/archive/exchange-reporter/reports/images/extraction-log-last-extraction.gif" width="986" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="948" src="/archive/exchange-reporter/reports/images/extraction-log-last-extraction.gif" width="986"/>

--- a/archive/exchange-reporter/reports/growth-all-mailboxes-month.htm
+++ b/archive/exchange-reporter/reports/growth-all-mailboxes-month.htm
@@ -1,1 +1,26 @@
-<img height="944" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes-month.gif" width="704" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="944" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes-month.gif" width="704"/>

--- a/archive/exchange-reporter/reports/growth-all-mailboxes.htm
+++ b/archive/exchange-reporter/reports/growth-all-mailboxes.htm
@@ -1,1 +1,26 @@
-<img height="538" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes.gif" width="747" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="538" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes.gif" width="747"/>

--- a/archive/exchange-reporter/reports/growth-individual-mailbox.htm
+++ b/archive/exchange-reporter/reports/growth-individual-mailbox.htm
@@ -1,1 +1,26 @@
-<img height="947" src="/archive/exchange-reporter/reports/images/growth-individual-mailbox.gif" width="674" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="947" src="/archive/exchange-reporter/reports/images/growth-individual-mailbox.gif" width="674"/>

--- a/archive/exchange-reporter/reports/incoming-busy-receivers-of-incoming-email.htm
+++ b/archive/exchange-reporter/reports/incoming-busy-receivers-of-incoming-email.htm
@@ -1,2 +1,26 @@
-<img height="948" src="/archive/exchange-reporter/reports/images/incoming-busy-receivers-of-incoming-email.gif"
-    width="968" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="948" src="/archive/exchange-reporter/reports/images/incoming-busy-receivers-of-incoming-email.gif" width="968"/>

--- a/archive/exchange-reporter/reports/incoming-received-emails-for-user.htm
+++ b/archive/exchange-reporter/reports/incoming-received-emails-for-user.htm
@@ -1,2 +1,26 @@
-<img height="947" src="/archive/exchange-reporter/reports/images/incoming-received-emails-for-user-date.gif"
-    width="973" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="947" src="/archive/exchange-reporter/reports/images/incoming-received-emails-for-user-date.gif" width="973"/>

--- a/archive/exchange-reporter/reports/mailboxes-summary.htm
+++ b/archive/exchange-reporter/reports/mailboxes-summary.htm
@@ -1,1 +1,26 @@
-<img height="947" src="/archive/exchange-reporter/reports/images/mailboxes-summary-extraction.gif" width="748" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="947" src="/archive/exchange-reporter/reports/images/mailboxes-summary-extraction.gif" width="748"/>

--- a/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-chart.htm
+++ b/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-chart.htm
@@ -1,1 +1,26 @@
-<img height="938" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-chart.gif" width="981" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="938" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-chart.gif" width="981"/>

--- a/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-l.htm
+++ b/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-l.htm
@@ -1,1 +1,26 @@
-<img height="943" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-l.gif" width="986" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="943" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-l.gif" width="986"/>

--- a/archive/exchange-reporter/reports/outgoing-top-50-busy.htm
+++ b/archive/exchange-reporter/reports/outgoing-top-50-busy.htm
@@ -1,1 +1,26 @@
-<img height="935" src="/archive/exchange-reporter/reports/images/outgoing-top-50-busy.gif" width="989" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="935" src="/archive/exchange-reporter/reports/images/outgoing-top-50-busy.gif" width="989"/>

--- a/archive/exchange-reporter/reports/outing-top-50-large-email.htm
+++ b/archive/exchange-reporter/reports/outing-top-50-large-email.htm
@@ -1,1 +1,26 @@
-<img height="943" src="/archive/exchange-reporter/reports/images/outing-top-50-large-email.gif" width="893" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="943" src="/archive/exchange-reporter/reports/images/outing-top-50-large-email.gif" width="893"/>

--- a/archive/exchange-reporter/reports/search-messages-by-email-address.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-email-address.htm
@@ -1,1 +1,26 @@
-<img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-email-address.gif" width="983" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-email-address.gif" width="983"/>

--- a/archive/exchange-reporter/reports/search-messages-by-key-phrase.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-key-phrase.htm
@@ -1,1 +1,26 @@
-<img height="951" src="/archive/exchange-reporter/reports/images/search-messages-by-key-phrase.gif" width="976" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="951" src="/archive/exchange-reporter/reports/images/search-messages-by-key-phrase.gif" width="976"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-advanced.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-advanced.htm
@@ -1,2 +1,26 @@
-<img height="910" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-advanced.gif"
-    width="1013" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="910" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-advanced.gif" width="1013"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-detail.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-detail.htm
@@ -1,1 +1,26 @@
-<img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-detail.gif" width="986" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-detail.gif" width="986"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-matrix.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-matrix.htm
@@ -1,1 +1,26 @@
-<img height="942" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-matrix.gif" width="718" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="942" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-matrix.gif" width="718"/>

--- a/archive/exchange-reporter/reports/trend-individual-mailbox.htm
+++ b/archive/exchange-reporter/reports/trend-individual-mailbox.htm
@@ -1,1 +1,26 @@
-<img height="706" src="/archive/exchange-reporter/reports/images/trend-individual-mailbox.gif" width="997" />
+
+<div style="
+            line-height: 1.5;
+            text-align: center; 
+            font-size: 1.125rem; 
+            color: #999;
+            background-color: #333333;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
+            padding-right: 0.75rem;
+            padding-left: 0.75rem;
+            ">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
+        ⚠️ This page has been archived
+    </div>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
+            ✅ New page with updated info:
+            <a href="https://www.ssw.com.au" style="color: white">
+                ssw.com.au
+            </a>
+</p>
+</div>
+</div>
+
+<img height="706" src="/archive/exchange-reporter/reports/images/trend-individual-mailbox.gif" width="997"/>


### PR DESCRIPTION
### Description

Some of the performance-pro pages contain badly formed html and thus didn't receive archive banners when the pages were ported. This PR fixes that issue on the effected pages.