### PR TITLE
Updated all products pages to link to /products

### DIFF
--- a/archive/access-reporter/0205-smart-access-extra.htm
+++ b/archive/access-reporter/0205-smart-access-extra.htm
@@ -31,9 +31,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/access-reporter/access-reporter-demo.html
+++ b/archive/access-reporter/access-reporter-demo.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/access-reporter/default.html
+++ b/archive/access-reporter/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/access-reporter/pdf-setup.htm
+++ b/archive/access-reporter/pdf-setup.htm
@@ -36,9 +36,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
 				✅ New page with updated info:
-				<a href="https://www.ssw.com.au" style="color: white">
-					ssw.com.au
-				</a>
+				<a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-merge-pro/default.html
+++ b/archive/data-merge-pro/default.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-merge-pro/tutorial.htm
+++ b/archive/data-merge-pro/tutorial.htm
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 
 <html>
-
 <head>
-        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-        <script>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+<script>
                 (function (w, d, s, l, i) {
                         w[l] = w[l] || []; w[l].push({
                                 'gtm.start':
@@ -14,20 +13,17 @@
                                         'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
                 })(window, document, 'script', 'dataLayer', 'GTM-NXDBVV');
         </script>
-        <title>
+<title>
                 SSW Merge Master
         </title>
-        <link href="/ssw/Include/sswmenu.css" rel="stylesheet" type="text/css" />
+<link href="/ssw/Include/sswmenu.css" rel="stylesheet" type="text/css"/>
 </head>
-
-<body alink="#003399" leftmargin="0" link="#003399" marginheight="0" marginwidth="0" text="#000000" topmargin="0"
-        vlink="#003399">
-        <noscript>
-                <iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-NXDBVV"
-                        style="display:none;visibility:hidden" width="0">
-                </iframe>
-        </noscript>
-        <div style="
+<body alink="#003399" leftmargin="0" link="#003399" marginheight="0" marginwidth="0" text="#000000" topmargin="0" vlink="#003399">
+<noscript>
+<iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-NXDBVV" style="display:none;visibility:hidden" width="0">
+</iframe>
+</noscript>
+<div style="
             line-height: 1.5;
             text-align: center; 
             font-size: 1.125rem; 
@@ -38,140 +34,132 @@
             padding-right: 0.75rem;
             padding-left: 0.75rem;
             ">
-                <div style="color: white; font-size: 2rem !important; font-weight: 600;">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
                         ⚠️ This page has been archived
                 </div>
-                <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
-                        <p>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
                                 ✅ New page with updated info:
-                                <a href="https://www.ssw.com.au" style="color: white">
-                                        ssw.com.au
-                                </a>
-                        </p>
-                </div>
-        </div>
-        <table bgcolor="white" border="0" cellpadding="0" cellspacing="0" width="100%">
-                <tr>
-                        <td align="left">
-                                <img alt="SSW Logo small" height="45" name="Image1"
-                                        src="/archive/ssw/images/sswsmall.gif" width="67" />
-                                <img alt="Merge Master" height="45"
-                                        src="/archive/data-merge-pro/images/merge-probanner.gif" width="525" />
-                                <img alt="header" height="45" src="/archive/ssw/images/hd-2.gif" width="200" />
-                        </td>
-                </tr>
-        </table>
-        <table bgcolor="white" border="0" cellpadding="0" cellspacing="0" width="101%">
-                <tr>
-                        <!-- spacer row - specify all others with colspan or rowspan-->
-                        <!--1-->
-                        <td width="11">
-                        </td>
-                        <!--2-->
-                        <td width="213">
-                        </td>
-                        <!--3-->
-                        <td width="1">
-                        </td>
-                        <!--4-->
-                        <td width="24">
-                        </td>
-                        <!--5-->
-                        <td width="362">
-                        </td>
-                        <!--6-->
-                        <td width="32">
-                        </td>
-                        <!--7-->
-                        <td width="97">
-                        </td>
-                        <!--8-->
-                        <td width="32">
-                        </td>
-                        <!--9-->
-                        <td width="208">
-                        </td>
-                        <!--10-->
-                        <td width="30">
-                        </td>
-                </tr>
-                <tr>
-                        <!-- spacer column -->
-                        <td colspan="2" rowspan="2" valign="top">
-                                <!--#include virtual="/ssw/"-->
-                        </td>
-                        <!-- spacer column -->
-                        <td bgcolor="#7d7d7d" rowspan="2" width="1">
-                        </td>
-                        <!-- spacer column -->
-                        <td rowspan="2" width="24">
-                        </td>
-                        <!--main content cell-->
-                        <td colspan="5" valign="top">
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+                                <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
+</p>
+</div>
+</div>
+<table bgcolor="white" border="0" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td align="left">
+<img alt="SSW Logo small" height="45" name="Image1" src="/archive/ssw/images/sswsmall.gif" width="67"/>
+<img alt="Merge Master" height="45" src="/archive/data-merge-pro/images/merge-probanner.gif" width="525"/>
+<img alt="header" height="45" src="/archive/ssw/images/hd-2.gif" width="200"/>
+</td>
+</tr>
+</table>
+<table bgcolor="white" border="0" cellpadding="0" cellspacing="0" width="101%">
+<tr>
+<!-- spacer row - specify all others with colspan or rowspan-->
+<!--1-->
+<td width="11">
+</td>
+<!--2-->
+<td width="213">
+</td>
+<!--3-->
+<td width="1">
+</td>
+<!--4-->
+<td width="24">
+</td>
+<!--5-->
+<td width="362">
+</td>
+<!--6-->
+<td width="32">
+</td>
+<!--7-->
+<td width="97">
+</td>
+<!--8-->
+<td width="32">
+</td>
+<!--9-->
+<td width="208">
+</td>
+<!--10-->
+<td width="30">
+</td>
+</tr>
+<tr>
+<!-- spacer column -->
+<td colspan="2" rowspan="2" valign="top">
+<!--#include virtual="/ssw/"-->
+</td>
+<!-- spacer column -->
+<td bgcolor="#7d7d7d" rowspan="2" width="1">
+</td>
+<!-- spacer column -->
+<td rowspan="2" width="24">
+</td>
+<!--main content cell-->
+<td colspan="5" valign="top">
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 SSW
                                                                 Merge PRO! Tutorial
                                                         </b>
-                                                </td>
-                                        </tr>
-                                        <tr>
-                                                <td>
-                                                        <img alt="Merge Pro" height="77"
-                                                                src="/archive/data-merge-pro/images/merge-pro.gif"
-                                                                width="167" />
-                                                </td>
-                                        </tr>
-                                </table>
-                                <p>
-                                        <br />
+</td>
+</tr>
+<tr>
+<td>
+<img alt="Merge Pro" height="77" src="/archive/data-merge-pro/images/merge-pro.gif" width="167"/>
+</td>
+</tr>
+</table>
+<p>
+<br/>
                                         SSW Merge RPO! is great utility that merges two different databases into one.
                                         The two databases can have different format i.e. MS Access, SQL Server and even
                                         have different structure i.e. different table names and different field names.
                                 </p>
-                                <p>
+<p>
                                         Merge RPO! use an user defined duplicate criteria to decide which records are
                                         duplicates. It is designed to work with any popular database, but currently has
                                         only been tested extensively on Access and SQL Server. If you are
                                         interested to try out on other database(s),
-                                        <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Enquiry%20Merge%20PRO!';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));"
-                                                title="info@ssw.com.au">
+                                        <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Enquiry%20Merge%20PRO!';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));" title="info@ssw.com.au">
                                                 let us know
                                         </a>
                                         ! 
                                 </p>
-                                <p>
+<p>
                                         When two databases are
                                         mergered, all records in the source database will be indicated how many
                                         duplicates may exist in the destination database, based on the user defined
                                         duplicate criteria. the user can then decide whether to add the source record
                                         into the destination database.
-                                        <br />
-                                        <br />
+                                        <br/>
+<br/>
                                         This screenshot below shows the result of merging Northwind with another SQL
                                         Server database.
-                                        <br />
-                                        <br />
-                                        <img alt="Sample Result" height="498"
-                                                src="/archive/data-merge-pro/images/sampleresult.gif" width="444" />
-                                        <br />
-                                </p>
-                                <p>
+                                        <br/>
+<br/>
+<img alt="Sample Result" height="498" src="/archive/data-merge-pro/images/sampleresult.gif" width="444"/>
+<br/>
+</p>
+<p>
                                         With the merge result,
                                         the user can decide what to do with the source data:
-                                        <br />
-                                </p>
-                                <ul>
-                                        <li>
+                                        <br/>
+</p>
+<ul>
+<li>
                                                 Add to the destination
                                                 withought any change.
                                         <li>
@@ -181,34 +169,34 @@
                                                 Compare with the
                                                 destination data first and modify before adding to destination database.
                                         </li>
-                                        </li>
-                                        </li>
-                                </ul>
-                                <p>
+</li>
+</li>
+</ul>
+<p>
                                         To learn more about how to use SSW Merge PRO! Please
                                         read SSW Merge PRO!
                                         <a href="tutorial.htm">
                                                 Tutoria
                                         </a>
-                                </p>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+</p>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 Features:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <ul>
-                                        <li>
+</td>
+</tr>
+</table>
+<ul>
+<li>
                                                 User Defined Duplicate
                                                 Criteria: Decide which records are duplicates based on same field value.
                                         <li>
@@ -228,193 +216,184 @@
                                                 UDL wizard: Launch an
                                                 UDL wizard to construct connection string.
                                         </li>
-                                        </li>
-                                        </li>
-                                        </li>
-                                        </li>
-                                </ul>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+</li>
+</li>
+</li>
+</li>
+</ul>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 Settings:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <br />
+</td>
+</tr>
+</table>
+<br/>
                                 Merge PRO! allows you
                                 to set a default destination database, so that when a new merge is created, it
                                 loads all default destination database information. Merge PRO! also allows you
                                 to set how many records to process on each processing.
-                                <br />
-                                <br />
-                                <img alt="Options" height="469" src="/archive/data-merge-pro/images/options.gif"
-                                        width="438" />
-                                <table cellpadding="0" style="LEFT: 0px; TOP: 1613px" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+                                <br/>
+<br/>
+<img alt="Options" height="469" src="/archive/data-merge-pro/images/options.gif" width="438"/>
+<table cellpadding="0" style="LEFT: 0px; TOP: 1613px" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 System
                                                                 Requirements:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <br />
+</td>
+</tr>
+</table>
+<br/>
                                 .NET frame work. You
                                 may download .Net Frame work for free from Microsoft (17.8MB).
                                 <a href="/ssw/Redirect/Net/DotNetFramework.htm" target="_blank">
-                                        <img alt="You are going to a site outside of SSW" border="0" height="8"
-                                                src="/archive/images/imgleavesite.gif" width="19" />
-                                </a>
-                                <br />
-                                <br />
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+<img alt="You are going to a site outside of SSW" border="0" height="8" src="/archive/images/imgleavesite.gif" width="19"/>
+</a>
+<br/>
+<br/>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 Installation
                                                                 Guide:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <br />
+</td>
+</tr>
+</table>
+<br/>
                                 When you run the
                                 install exe there is a simple wizard interface to guide you thru the setup
                                 process. All you have to do is select which directory you want SSW Merge PRO!
                                 to be installed into.
-                                <br />
-                                <br />
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td>
+                                <br/>
+<br/>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td>
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td height="17">
-                                                        <b>
-                                                                <a name="MediaMonit">
-                                                                </a>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td height="17">
+<b>
+<a name="MediaMonit">
+</a>
                                                                 Getting Support:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <br />
+</td>
+</tr>
+</table>
+<br/>
                                 If you can't find it in the product documentation then check our
                                 <a href="/ssw/KB/KB.aspx">
                                         knowledge base
                                 </a>
                                 for further information and tips about this product.
-                                <br />
-                                <br />
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+                                <br/>
+<br/>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 Download
                                                                 the 30 day trial:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <br />
+</td>
+</tr>
+</table>
+<br/>
                                 Click here to download
                                 SSW Merge PRO!.
                                 <a href="/ssw/Download/download.asp">
-                                        <img alt="Download" border="0" height="16" src="/archive/images/download.gif"
-                                                width="19" />
-                                </a>
-                                <br />
-                                <br />
+<img alt="Download" border="0" height="16" src="/archive/images/download.gif" width="19"/>
+</a>
+<br/>
+<br/>
                                 Please send us
-                                <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Bug%20Reports';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));"
-                                        title="info@ssw.com.au">
+                                <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Bug%20Reports';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));" title="info@ssw.com.au">
                                         bug reports
                                 </a>
                                 and
-                                <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Feedback';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));"
-                                        title="info@ssw.com.au">
+                                <a href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info', e4='?Subject=Feedback';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));" title="info@ssw.com.au">
                                         feedback
                                 </a>
                                 so that we can evolve SSW Merge PRO! into a product that
                                 matches your requirements.
-                                <br />
-                                <br />
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#ff0033">
-                                                <td align="right">
+                                <br/>
+<br/>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#ff0033">
+<td align="right">
                                                         .
                                                 </td>
-                                        </tr>
-                                </table>
-                                <table cellpadding="0" width="100%">
-                                        <tr bgcolor="#cccccc">
-                                                <td>
-                                                        <b>
+</tr>
+</table>
+<table cellpadding="0" width="100%">
+<tr bgcolor="#cccccc">
+<td>
+<b>
                                                                 Purchasing
                                                                 Information:
                                                         </b>
-                                                </td>
-                                        </tr>
-                                </table>
-                                <p>
-                                        <a href="/ssw/products/newprodcategory.aspx">
+</td>
+</tr>
+</table>
+<p>
+<a href="/ssw/products/newprodcategory.aspx">
                                                 Information on
                                                 purchasing SSW Merge PRO! and other SSW products
                                         </a>
                                         . Merge PRO! has a volume pricing strategy, please refer to this pricing page.
                                 </p>
-                                <center>
-                                        <img alt="Footer SSW" border="0" height="45"
-                                                src="/archive/ssw/images/ft-ssw.gif" usemap="#MapMap" width="300" />
-                                        <map name="MapMap">
-                                                <area coords="206,16,296,29"
-                                                        href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info, e4='?Subject=Employment';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));"
-                                                        shape="RECT" title="info@ssw.com.au" />
-                                                <area coords="60,17,151,28" href="/ssw/" shape="RECT" />
-                                        </map>
-                                </center>
-                        <td rowspan="2" width="30">
-                        </td>
-                        </td>
-                </tr>
-                <tr>
-                </tr>
-        </table>
+<center>
+<img alt="Footer SSW" border="0" height="45" src="/archive/ssw/images/ft-ssw.gif" usemap="#MapMap" width="300"/>
+<map name="MapMap">
+<area coords="206,16,296,29" href="javascript:var e1='s%73%77.%63%6f%6d%2e%61%75',e2='mailto:%20', e3='info, e4='?Subject=Employment';var e0=e2+e3+'@'+e1+e4;(window.location?window.location.replace(e0):document.write(e0));" shape="RECT" title="info@ssw.com.au"/>
+<area coords="60,17,151,28" href="/ssw/" shape="RECT"/>
+</map>
+</center>
+<td rowspan="2" width="30">
+</td>
+</td>
+</tr>
+<tr>
+</tr>
+</table>
 </body>
-
 </html>

--- a/archive/data-merge-pro/tutorial.html
+++ b/archive/data-merge-pro/tutorial.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/01-introduction.htm
+++ b/archive/data-pro/access/01-introduction.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/02-how-it-works.htm
+++ b/archive/data-pro/access/02-how-it-works.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/03-assumptions.htm
+++ b/archive/data-pro/access/03-assumptions.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/04-getting-started.htm
+++ b/archive/data-pro/access/04-getting-started.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/05-first-time-use.htm
+++ b/archive/data-pro/access/05-first-time-use.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/06-setup.htm
+++ b/archive/data-pro/access/06-setup.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/07-tutorial.htm
+++ b/archive/data-pro/access/07-tutorial.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/08-changing-data.htm
+++ b/archive/data-pro/access/08-changing-data.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/09-data-structure.htm
+++ b/archive/data-pro/access/09-data-structure.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/10-data.htm
+++ b/archive/data-pro/access/10-data.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/11-relationship.htm
+++ b/archive/data-pro/access/11-relationship.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/12-dataindex.htm
+++ b/archive/data-pro/access/12-dataindex.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/13comments.htm
+++ b/archive/data-pro/access/13comments.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/access/14-distribute-front-end.htm
+++ b/archive/data-pro/access/14-distribute-front-end.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/default.html
+++ b/archive/data-pro/default.html
@@ -76,9 +76,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/01-introduction-sql.htm
+++ b/archive/data-pro/sql/01-introduction-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/02-how-it-works-sql.htm
+++ b/archive/data-pro/sql/02-how-it-works-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/03-assumptions-sql.htm
+++ b/archive/data-pro/sql/03-assumptions-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/04-getting-started-sql.htm
+++ b/archive/data-pro/sql/04-getting-started-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/05-first-time-use-sql.htm
+++ b/archive/data-pro/sql/05-first-time-use-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/06-setup-sql.htm
+++ b/archive/data-pro/sql/06-setup-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/07-tutorial-sql.htm
+++ b/archive/data-pro/sql/07-tutorial-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/08-changing-data-sql.htm
+++ b/archive/data-pro/sql/08-changing-data-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-pro/sql/09-distribute-front-end-sql.htm
+++ b/archive/data-pro/sql/09-distribute-front-end-sql.htm
@@ -38,9 +38,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-renovator/default.html
+++ b/archive/data-renovator/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/data-renovator/user-guide.html
+++ b/archive/data-renovator/user-guide.html
@@ -564,9 +564,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/email-merge-pro/default.html
+++ b/archive/email-merge-pro/default.html
@@ -77,9 +77,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/email-merge-pro/userguide.html
+++ b/archive/email-merge-pro/userguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/exchange-reporter/default.html
+++ b/archive/exchange-reporter/default.html
@@ -86,9 +86,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                                 ✅ New page with updated info:
-                                <a href="https://www.ssw.com.au" style="color: white">
-                                        ssw.com.au
-                                </a>
+                                <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/exchange-reporter/report-samples.html
+++ b/archive/exchange-reporter/report-samples.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/exchange-reporter/reports/current-all-mailboxes-folder-l.htm
+++ b/archive/exchange-reporter/reports/current-all-mailboxes-folder-l.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="871" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder-l.gif" width="1026"/>

--- a/archive/exchange-reporter/reports/current-all-mailboxes-folder.htm
+++ b/archive/exchange-reporter/reports/current-all-mailboxes-folder.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="940" src="/archive/exchange-reporter/reports/images/current-all-mailboxes-folder.gif" width="1257"/>

--- a/archive/exchange-reporter/reports/current-folder-tree-sizes-all.htm
+++ b/archive/exchange-reporter/reports/current-folder-tree-sizes-all.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="944" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-all.gif" width="975"/>

--- a/archive/exchange-reporter/reports/current-folder-tree-sizes-owner.htm
+++ b/archive/exchange-reporter/reports/current-folder-tree-sizes-owner.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="896" src="/archive/exchange-reporter/reports/images/current-folder-tree-sizes-owner.gif" width="1021"/>

--- a/archive/exchange-reporter/reports/default.html
+++ b/archive/exchange-reporter/reports/default.html
@@ -8929,9 +8929,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/exchange-reporter/reports/extraction-log-all-records.htm
+++ b/archive/exchange-reporter/reports/extraction-log-all-records.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="946" src="/archive/exchange-reporter/reports/images/extraction-log-all-records.gif" width="965"/>

--- a/archive/exchange-reporter/reports/extraction-log-last-extraction.htm
+++ b/archive/exchange-reporter/reports/extraction-log-last-extraction.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="948" src="/archive/exchange-reporter/reports/images/extraction-log-last-extraction.gif" width="986"/>

--- a/archive/exchange-reporter/reports/growth-all-mailboxes-month.htm
+++ b/archive/exchange-reporter/reports/growth-all-mailboxes-month.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="944" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes-month.gif" width="704"/>

--- a/archive/exchange-reporter/reports/growth-all-mailboxes.htm
+++ b/archive/exchange-reporter/reports/growth-all-mailboxes.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="538" src="/archive/exchange-reporter/reports/images/growth-all-mailboxes.gif" width="747"/>

--- a/archive/exchange-reporter/reports/growth-individual-mailbox.htm
+++ b/archive/exchange-reporter/reports/growth-individual-mailbox.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="947" src="/archive/exchange-reporter/reports/images/growth-individual-mailbox.gif" width="674"/>

--- a/archive/exchange-reporter/reports/incoming-busy-receivers-of-incoming-email.htm
+++ b/archive/exchange-reporter/reports/incoming-busy-receivers-of-incoming-email.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="948" src="/archive/exchange-reporter/reports/images/incoming-busy-receivers-of-incoming-email.gif" width="968"/>

--- a/archive/exchange-reporter/reports/incoming-received-emails-for-user.htm
+++ b/archive/exchange-reporter/reports/incoming-received-emails-for-user.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="947" src="/archive/exchange-reporter/reports/images/incoming-received-emails-for-user-date.gif" width="973"/>

--- a/archive/exchange-reporter/reports/mailboxes-summary.htm
+++ b/archive/exchange-reporter/reports/mailboxes-summary.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="947" src="/archive/exchange-reporter/reports/images/mailboxes-summary-extraction.gif" width="748"/>

--- a/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-chart.htm
+++ b/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-chart.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="938" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-chart.gif" width="981"/>

--- a/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-l.htm
+++ b/archive/exchange-reporter/reports/outgoing-sent-emails-for-user-l.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="943" src="/archive/exchange-reporter/reports/images/outgoing-sent-emails-for-user-l.gif" width="986"/>

--- a/archive/exchange-reporter/reports/outgoing-top-50-busy.htm
+++ b/archive/exchange-reporter/reports/outgoing-top-50-busy.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="935" src="/archive/exchange-reporter/reports/images/outgoing-top-50-busy.gif" width="989"/>

--- a/archive/exchange-reporter/reports/outing-top-50-large-email.htm
+++ b/archive/exchange-reporter/reports/outing-top-50-large-email.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="943" src="/archive/exchange-reporter/reports/images/outing-top-50-large-email.gif" width="893"/>

--- a/archive/exchange-reporter/reports/search-messages-by-email-address.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-email-address.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-email-address.gif" width="983"/>

--- a/archive/exchange-reporter/reports/search-messages-by-key-phrase.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-key-phrase.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="951" src="/archive/exchange-reporter/reports/images/search-messages-by-key-phrase.gif" width="976"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-advanced.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-advanced.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="910" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-advanced.gif" width="1013"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-detail.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-detail.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="943" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-detail.gif" width="986"/>

--- a/archive/exchange-reporter/reports/search-messages-by-keywords-matrix.htm
+++ b/archive/exchange-reporter/reports/search-messages-by-keywords-matrix.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="942" src="/archive/exchange-reporter/reports/images/search-messages-by-keywords-matrix.gif" width="718"/>

--- a/archive/exchange-reporter/reports/trend-individual-mailbox.htm
+++ b/archive/exchange-reporter/reports/trend-individual-mailbox.htm
@@ -16,11 +16,8 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
             ✅ New page with updated info:
-            <a href="https://www.ssw.com.au" style="color: white">
-                ssw.com.au
-            </a>
+            <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>
-
 <img height="706" src="/archive/exchange-reporter/reports/images/trend-individual-mailbox.gif" width="997"/>

--- a/archive/exchange-reporter/user-guide.html
+++ b/archive/exchange-reporter/user-guide.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/default.html
+++ b/archive/extreme-emails/default.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/excel-product-list/default.html
+++ b/archive/extreme-emails/excel-product-list/default.html
@@ -50,9 +50,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                         ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/default.html
+++ b/archive/extreme-emails/reports/default.html
@@ -8929,9 +8929,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/new-version-released-report.htm
+++ b/archive/extreme-emails/reports/new-version-released-report.htm
@@ -704,9 +704,7 @@ ul
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/pre-release-summary-report.htm
+++ b/archive/extreme-emails/reports/pre-release-summary-report.htm
@@ -449,9 +449,7 @@ table.HeaderTable
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/release-debrief-report.htm
+++ b/archive/extreme-emails/reports/release-debrief-report.htm
@@ -706,9 +706,7 @@ ul
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/release-plan-report.htm
+++ b/archive/extreme-emails/reports/release-plan-report.htm
@@ -549,9 +549,7 @@ table.HeaderTable
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/revised-estimate.htm
+++ b/archive/extreme-emails/reports/revised-estimate.htm
@@ -477,9 +477,7 @@ table.HeaderTable
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/test-please-report.htm
+++ b/archive/extreme-emails/reports/test-please-report.htm
@@ -1144,9 +1144,7 @@ table.HeaderTable
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/update-report-files/header.htm
+++ b/archive/extreme-emails/reports/update-report-files/header.htm
@@ -32,9 +32,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/reports/update-report.htm
+++ b/archive/extreme-emails/reports/update-report.htm
@@ -734,9 +734,7 @@ div.Section1
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/extreme-emails/userguide.html
+++ b/archive/extreme-emails/userguide.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/health-auditor/default.html
+++ b/archive/health-auditor/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/health-auditor/fx-cop-tutorial.html
+++ b/archive/health-auditor/fx-cop-tutorial.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/health-auditor/nunit-tutorial.html
+++ b/archive/health-auditor/nunit-tutorial.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/health-auditor/userguide.html
+++ b/archive/health-auditor/userguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/link-auditor/default.html
+++ b/archive/link-auditor/default.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/link-auditor/desktop/user-guide.html
+++ b/archive/link-auditor/desktop/user-guide.html
@@ -8929,9 +8929,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/link-auditor/howtobe-good-link-auditor-daily-build-master.html
+++ b/archive/link-auditor/howtobe-good-link-auditor-daily-build-master.html
@@ -8929,9 +8929,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/link-auditor/last-report.htm
+++ b/archive/link-auditor/last-report.htm
@@ -1,9 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 
 <html>
-
 <head>
-    <script>
+<script>
         (function (w, d, s, l, i) {
             w[l] = w[l] || []; w[l].push({
                 'gtm.start':
@@ -13,11 +12,11 @@
                     'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-NXDBVV');
     </script>
-    <title>SSW Link Auditor Report</title>
-    <link href="/ssw/Include/ssw.css" rel="stylesheet" type="text/css" />
-    <link href="/ssw/Images/IcoSSW_v2.ico" rel="shortcut icon" />
-    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-    <style>
+<title>SSW Link Auditor Report</title>
+<link href="/ssw/Include/ssw.css" rel="stylesheet" type="text/css"/>
+<link href="/ssw/Images/IcoSSW_v2.ico" rel="shortcut icon"/>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+<style>
         BODY {
             FONT: 8pt Verdana
         }
@@ -57,12 +56,10 @@
             TEXT-DECORATION: underline
         }
     </style>
-    <meta content="MSHTML 6.00.2800.1400" name="GENERATOR" />
+<meta content="MSHTML 6.00.2800.1400" name="GENERATOR"/>
 </head>
-
-<body onload="initialize()"><noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-NXDBVV"
-            style="display:none;visibility:hidden" width="0"></iframe></noscript>
-    <div style="
+<body onload="initialize()"><noscript><iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-NXDBVV" style="display:none;visibility:hidden" width="0"></iframe></noscript>
+<div style="
             line-height: 1.5;
             text-align: center; 
             font-size: 1.125rem; 
@@ -73,400 +70,387 @@
             padding-right: 0.75rem;
             padding-left: 0.75rem;
             ">
-        <div style="color: white; font-size: 2rem !important; font-weight: 600;">
+<div style="color: white; font-size: 2rem !important; font-weight: 600;">
             ⚠️ This page has been archived
         </div>
-        <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
-            <p>
+<div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
+<p>
                 ✅ New page with updated info:
-                <a href="https://www.ssw.com.au" style="color: white">
-                    ssw.com.au
-                </a>
-            </p>
-        </div>
-    </div>
-    <table width="100%">
-        <tbody>
-            <tr>
-                <td>
-                    <h1>SSW Link Auditor Report</h1>
-                </td>
-                <td valign="top"></td>
-            </tr>
-        </tbody>
-    </table>
-    <table id="StatsTable">
-        <colgroup>
-            <col width="180" />
-            <col />
-        </colgroup>
-        <tbody>
-            <tr>
-                <td><b>Initial URI:</b>
-                </td>
-                <td>http://localhost/</td>
-            </tr>
-            <tr>
-                <td><b>Beyond Domain:</b>
-                </td>
-                <td>False</td>
-            </tr>
-            <tr>
-                <td><b>Time Started:</b>
-                </td>
-                <td>5/31/2004 10:19:24 AM</td>
-            </tr>
-            <tr>
-                <td><b>Time Finished:</b>
-                </td>
-                <td>5/31/2004 10:19:25 AM</td>
-            </tr>
-            <tr>
-                <td><b>Time Elapsed:</b>
-                </td>
-                <td>00:00:00:00</td>
-            </tr>
-            <tr>
-                <td><b>Total Targets:</b>
-                </td>
-                <td>9</td>
-            </tr>
-            <tr>
-                <td><b>Total Links:</b>
-                </td>
-                <td>9</td>
-            </tr>
-            <tr>
-                <td><b>Average Links Per Page:</b>
-                </td>
-                <td>1</td>
-            </tr>
-            <tr>
-                <td><b>Warning Count:</b>
-                </td>
-                <td>0</td>
-            </tr>
-            <tr>
-                <td><b>Failure Count:</b>
-                </td>
-                <td>0</td>
-            </tr>
-        </tbody>
-    </table>
-    <br />
-    <table id="ReportEntries" width="100%">
-        <colgroup>
-            <col align="middle" />
-        </colgroup>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S1" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/helpgif.htm" target="_blank">http://localhost/help.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS1" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>3988</td>
-                                <td>19</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S2" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/colegal.htm" target="_blank">http://localhost/iishelp/common/colegal.htm</a>
-                </td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS2" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>5687</td>
-                                <td>37</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S3" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/iisstart.htm" target="_blank">http://localhost/iisstart.asp?uc=1</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS3" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>1332</td>
-                                <td>27</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S4" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/mmc.htm" target="_blank">http://localhost/mmc.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS4" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>3125</td>
-                                <td>18</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S5" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/pagerror.htm" target="_blank">http://localhost/pagerror.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS5" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/iisstart.htm"
-                                        target="_blank">http://localhost/iisstart.asp?uc=1</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>269</td>
-                                <td>40</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S6" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/print.htm" target="_blank">http://localhost/print.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS6" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>5093</td>
-                                <td>20</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S7" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/warning.htm" target="_blank">http://localhost/warning.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS7" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>993</td>
-                                <td>22</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S8" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/web.htm" target="_blank">http://localhost/web.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS8" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>1833</td>
-                                <td>18</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-        <tbody class="ReportEntryTBody">
-            <tr>
-                <td><img alt="Expand" class="OutlineControl" height="10" position="S9" src="/archive/images/plus.gif"
-                        width="10" />
-                </td>
-                <td><a href="/ssw/Redirect/winXP.htm" target="_blank">http://localhost/winXP.gif</a></td>
-                <td>Success</td>
-            </tr>
-            <tr classname="EntryLinks" id="EntryS9" style="DISPLAY: none">
-                <td colspan="3" style="PADDING-LEFT: 40px">
-                    <table width="100%">
-                        <thead>
-                            <tr>
-                                <td>Source</td>
-                                <td width="75">Type</td>
-                                <td width="75">Style</td>
-                                <td width="75">Index</td>
-                                <td width="75">Length</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
-                                </td>
-                                <td></td>
-                                <td></td>
-                                <td>787</td>
-                                <td>20</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+                <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
+</p>
+</div>
+</div>
+<table width="100%">
+<tbody>
+<tr>
+<td>
+<h1>SSW Link Auditor Report</h1>
+</td>
+<td valign="top"></td>
+</tr>
+</tbody>
+</table>
+<table id="StatsTable">
+<colgroup>
+<col width="180"/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<td><b>Initial URI:</b>
+</td>
+<td>http://localhost/</td>
+</tr>
+<tr>
+<td><b>Beyond Domain:</b>
+</td>
+<td>False</td>
+</tr>
+<tr>
+<td><b>Time Started:</b>
+</td>
+<td>5/31/2004 10:19:24 AM</td>
+</tr>
+<tr>
+<td><b>Time Finished:</b>
+</td>
+<td>5/31/2004 10:19:25 AM</td>
+</tr>
+<tr>
+<td><b>Time Elapsed:</b>
+</td>
+<td>00:00:00:00</td>
+</tr>
+<tr>
+<td><b>Total Targets:</b>
+</td>
+<td>9</td>
+</tr>
+<tr>
+<td><b>Total Links:</b>
+</td>
+<td>9</td>
+</tr>
+<tr>
+<td><b>Average Links Per Page:</b>
+</td>
+<td>1</td>
+</tr>
+<tr>
+<td><b>Warning Count:</b>
+</td>
+<td>0</td>
+</tr>
+<tr>
+<td><b>Failure Count:</b>
+</td>
+<td>0</td>
+</tr>
+</tbody>
+</table>
+<br/>
+<table id="ReportEntries" width="100%">
+<colgroup>
+<col align="middle"/>
+</colgroup>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S1" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/helpgif.htm" target="_blank">http://localhost/help.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS1" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>3988</td>
+<td>19</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S2" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/colegal.htm" target="_blank">http://localhost/iishelp/common/colegal.htm</a>
+</td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS2" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>5687</td>
+<td>37</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S3" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/iisstart.htm" target="_blank">http://localhost/iisstart.asp?uc=1</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS3" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>1332</td>
+<td>27</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S4" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/mmc.htm" target="_blank">http://localhost/mmc.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS4" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>3125</td>
+<td>18</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S5" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/pagerror.htm" target="_blank">http://localhost/pagerror.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS5" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/iisstart.htm" target="_blank">http://localhost/iisstart.asp?uc=1</a>
+</td>
+<td></td>
+<td></td>
+<td>269</td>
+<td>40</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S6" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/print.htm" target="_blank">http://localhost/print.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS6" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>5093</td>
+<td>20</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S7" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/warning.htm" target="_blank">http://localhost/warning.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS7" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>993</td>
+<td>22</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S8" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/web.htm" target="_blank">http://localhost/web.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS8" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>1833</td>
+<td>18</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+<tbody class="ReportEntryTBody">
+<tr>
+<td><img alt="Expand" class="OutlineControl" height="10" position="S9" src="/archive/images/plus.gif" width="10"/>
+</td>
+<td><a href="/ssw/Redirect/winXP.htm" target="_blank">http://localhost/winXP.gif</a></td>
+<td>Success</td>
+</tr>
+<tr classname="EntryLinks" id="EntryS9" style="DISPLAY: none">
+<td colspan="3" style="PADDING-LEFT: 40px">
+<table width="100%">
+<thead>
+<tr>
+<td>Source</td>
+<td width="75">Type</td>
+<td width="75">Style</td>
+<td width="75">Index</td>
+<td width="75">Length</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ssw/Redirect/localhost.htm" target="_blank">http://localhost/</a>
+</td>
+<td></td>
+<td></td>
+<td>787</td>
+<td>20</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
 </body>
-
 </html>

--- a/archive/link-auditor/user-guide.html
+++ b/archive/link-auditor/user-guide.html
@@ -8929,9 +8929,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/look-out/sample/customer.html
+++ b/archive/look-out/sample/customer.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/look-out/user-guide.html
+++ b/archive/look-out/user-guide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/01-win-validator.html
+++ b/archive/net-toolkit/01-win-validator.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/02-win-search.html
+++ b/archive/net-toolkit/02-win-search.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/03-data-entry.html
+++ b/archive/net-toolkit/03-data-entry.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/04-exception-reporter.html
+++ b/archive/net-toolkit/04-exception-reporter.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/05-wizard-forms.html
+++ b/archive/net-toolkit/05-wizard-forms.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/06-configuration-block.html
+++ b/archive/net-toolkit/06-configuration-block.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/07-version-checker.html
+++ b/archive/net-toolkit/07-version-checker.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/08-progressbars-statusforms.html
+++ b/archive/net-toolkit/08-progressbars-statusforms.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/default.html
+++ b/archive/net-toolkit/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/net-toolkit/user-guide.html
+++ b/archive/net-toolkit/user-guide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/performance-pro/default.html
+++ b/archive/performance-pro/default.html
@@ -8931,9 +8931,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
         ✅ New page with updated info:
-        <a href="https://www.ssw.com.au" style="color: white">
-          ssw.com.au
-        </a>
+        <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/performance-pro/user-guide.html
+++ b/archive/performance-pro/user-guide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-auditor/default.html
+++ b/archive/sql-auditor/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-auditor/sample-report.html
+++ b/archive/sql-auditor/sample-report.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-auditor/userguide-wizards.html
+++ b/archive/sql-auditor/userguide-wizards.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-auditor/userguide.html
+++ b/archive/sql-auditor/userguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-deploy/developerguide.html
+++ b/archive/sql-deploy/developerguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-deploy/exe-mode.html
+++ b/archive/sql-deploy/exe-mode.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-deploy/existing-data-base.html
+++ b/archive/sql-deploy/existing-data-base.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-deploy/integration-mode.html
+++ b/archive/sql-deploy/integration-mode.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-deploy/userguide.html
+++ b/archive/sql-deploy/userguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-reporting-services-auditor/default.html
+++ b/archive/sql-reporting-services-auditor/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-reporting-services-auditor/post-installation.html
+++ b/archive/sql-reporting-services-auditor/post-installation.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-reporting-services-auditor/user-guide.html
+++ b/archive/sql-reporting-services-auditor/user-guide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-total-compare/default.html
+++ b/archive/sql-total-compare/default.html
@@ -564,9 +564,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/sql-total-compare/userguide.html
+++ b/archive/sql-total-compare/userguide.html
@@ -564,9 +564,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/activesync.html
+++ b/archive/standards/better-software-suggestions/activesync.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/antispyware.html
+++ b/archive/standards/better-software-suggestions/antispyware.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/aspnet.html
+++ b/archive/standards/better-software-suggestions/aspnet.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/asterix.html
+++ b/archive/standards/better-software-suggestions/asterix.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/bing.html
+++ b/archive/standards/better-software-suggestions/bing.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/blinq.html
+++ b/archive/standards/better-software-suggestions/blinq.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/camtasia.html
+++ b/archive/standards/better-software-suggestions/camtasia.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/crm.html
+++ b/archive/standards/better-software-suggestions/crm.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/dataanalyzer.html
+++ b/archive/standards/better-software-suggestions/dataanalyzer.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/default.html
+++ b/archive/standards/better-software-suggestions/default.html
@@ -564,9 +564,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/dnn.html
+++ b/archive/standards/better-software-suggestions/dnn.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/dot-net-nuke.html
+++ b/archive/standards/better-software-suggestions/dot-net-nuke.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/dotnet.html
+++ b/archive/standards/better-software-suggestions/dotnet.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/dynamic-data.html
+++ b/archive/standards/better-software-suggestions/dynamic-data.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/exchange.html
+++ b/archive/standards/better-software-suggestions/exchange.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/expression-blend.html
+++ b/archive/standards/better-software-suggestions/expression-blend.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/expression-suite.html
+++ b/archive/standards/better-software-suggestions/expression-suite.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/expression.html
+++ b/archive/standards/better-software-suggestions/expression.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/facebook.html
+++ b/archive/standards/better-software-suggestions/facebook.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/foursquare.html
+++ b/archive/standards/better-software-suggestions/foursquare.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/google-analytics.html
+++ b/archive/standards/better-software-suggestions/google-analytics.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/google.html
+++ b/archive/standards/better-software-suggestions/google.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/hohm.html
+++ b/archive/standards/better-software-suggestions/hohm.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/hyper-v.html
+++ b/archive/standards/better-software-suggestions/hyper-v.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/iis.html
+++ b/archive/standards/better-software-suggestions/iis.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/instyler.html
+++ b/archive/standards/better-software-suggestions/instyler.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/isaserver.html
+++ b/archive/standards/better-software-suggestions/isaserver.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/linq.html
+++ b/archive/standards/better-software-suggestions/linq.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/live-meeting.html
+++ b/archive/standards/better-software-suggestions/live-meeting.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/live-writer.html
+++ b/archive/standards/better-software-suggestions/live-writer.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/media-player.html
+++ b/archive/standards/better-software-suggestions/media-player.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/mediacenter.html
+++ b/archive/standards/better-software-suggestions/mediacenter.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/microsoft-project.html
+++ b/archive/standards/better-software-suggestions/microsoft-project.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/msajax.html
+++ b/archive/standards/better-software-suggestions/msajax.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/msdn.html
+++ b/archive/standards/better-software-suggestions/msdn.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/msform.html
+++ b/archive/standards/better-software-suggestions/msform.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/msnmessenger.html
+++ b/archive/standards/better-software-suggestions/msnmessenger.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/mswebsite.html
+++ b/archive/standards/better-software-suggestions/mswebsite.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/myob.html
+++ b/archive/standards/better-software-suggestions/myob.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/net-tiers.html
+++ b/archive/standards/better-software-suggestions/net-tiers.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/performance-point.html
+++ b/archive/standards/better-software-suggestions/performance-point.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/plaxo.html
+++ b/archive/standards/better-software-suggestions/plaxo.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/pluralsight.html
+++ b/archive/standards/better-software-suggestions/pluralsight.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/project-server-integration.html
+++ b/archive/standards/better-software-suggestions/project-server-integration.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/project-server.html
+++ b/archive/standards/better-software-suggestions/project-server.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/project-tfs.html
+++ b/archive/standards/better-software-suggestions/project-tfs.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/project.html
+++ b/archive/standards/better-software-suggestions/project.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/query-designer.html
+++ b/archive/standards/better-software-suggestions/query-designer.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/reporting-service-report-builder.html
+++ b/archive/standards/better-software-suggestions/reporting-service-report-builder.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/reporting-services.html
+++ b/archive/standards/better-software-suggestions/reporting-services.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/rescue-time.html
+++ b/archive/standards/better-software-suggestions/rescue-time.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/rules-to-better-xda.html
+++ b/archive/standards/better-software-suggestions/rules-to-better-xda.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/sharepoint.html
+++ b/archive/standards/better-software-suggestions/sharepoint.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/silverlight.html
+++ b/archive/standards/better-software-suggestions/silverlight.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/skype.html
+++ b/archive/standards/better-software-suggestions/skype.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/smh.html
+++ b/archive/standards/better-software-suggestions/smh.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/snagit.html
+++ b/archive/standards/better-software-suggestions/snagit.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/source-safe.html
+++ b/archive/standards/better-software-suggestions/source-safe.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/sqlserver-olap.html
+++ b/archive/standards/better-software-suggestions/sqlserver-olap.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/sqlserver.html
+++ b/archive/standards/better-software-suggestions/sqlserver.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/sugar-sync.html
+++ b/archive/standards/better-software-suggestions/sugar-sync.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/team-companion.html
+++ b/archive/standards/better-software-suggestions/team-companion.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/team-foundation-server-2010.html
+++ b/archive/standards/better-software-suggestions/team-foundation-server-2010.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/team-foundation-server.html
+++ b/archive/standards/better-software-suggestions/team-foundation-server.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik-aspweb.html
+++ b/archive/standards/better-software-suggestions/telerik-aspweb.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik-sharepoint-acceleration-kit.html
+++ b/archive/standards/better-software-suggestions/telerik-sharepoint-acceleration-kit.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik-test-studio.html
+++ b/archive/standards/better-software-suggestions/telerik-test-studio.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik-tests.html
+++ b/archive/standards/better-software-suggestions/telerik-tests.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik-windows-forms.html
+++ b/archive/standards/better-software-suggestions/telerik-windows-forms.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/telerik.html
+++ b/archive/standards/better-software-suggestions/telerik.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/terminalservices.html
+++ b/archive/standards/better-software-suggestions/terminalservices.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tfs-azure.html
+++ b/archive/standards/better-software-suggestions/tfs-azure.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tfs-twa-portal.html
+++ b/archive/standards/better-software-suggestions/tfs-twa-portal.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tfs-vsscrum-process.html
+++ b/archive/standards/better-software-suggestions/tfs-vsscrum-process.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tfsdebugger-canvas.html
+++ b/archive/standards/better-software-suggestions/tfsdebugger-canvas.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tfssidekicks.html
+++ b/archive/standards/better-software-suggestions/tfssidekicks.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/tweetdeck.html
+++ b/archive/standards/better-software-suggestions/tweetdeck.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/vbuildpro.html
+++ b/archive/standards/better-software-suggestions/vbuildpro.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/virtual-earth.html
+++ b/archive/standards/better-software-suggestions/virtual-earth.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/virtual-pc.html
+++ b/archive/standards/better-software-suggestions/virtual-pc.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/vista.html
+++ b/archive/standards/better-software-suggestions/vista.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/visual-studio.html
+++ b/archive/standards/better-software-suggestions/visual-studio.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/vsbuild-and-deploy.html
+++ b/archive/standards/better-software-suggestions/vsbuild-and-deploy.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/vstt.html
+++ b/archive/standards/better-software-suggestions/vstt.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/whats-app.html
+++ b/archive/standards/better-software-suggestions/whats-app.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows-2008r-2.html
+++ b/archive/standards/better-software-suggestions/windows-2008r-2.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows-7.html
+++ b/archive/standards/better-software-suggestions/windows-7.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows-desktop-search.html
+++ b/archive/standards/better-software-suggestions/windows-desktop-search.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows-mobile.html
+++ b/archive/standards/better-software-suggestions/windows-mobile.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows-pho-to-viewer.html
+++ b/archive/standards/better-software-suggestions/windows-pho-to-viewer.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/windows.html
+++ b/archive/standards/better-software-suggestions/windows.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/wise.html
+++ b/archive/standards/better-software-suggestions/wise.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/standards/better-software-suggestions/wpf.html
+++ b/archive/standards/better-software-suggestions/wpf.html
@@ -47,9 +47,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p style="color:white;">
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/default.html
+++ b/archive/team-calendar/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/howtobooksomeoneformeeting.html
+++ b/archive/team-calendar/howtobooksomeoneformeeting.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/installation/create-user.htm
+++ b/archive/team-calendar/installation/create-user.htm
@@ -30,9 +30,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/installation/exchange-permissions.htm
+++ b/archive/team-calendar/installation/exchange-permissions.htm
@@ -30,9 +30,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/installation/iispermissions.htm
+++ b/archive/team-calendar/installation/iispermissions.htm
@@ -30,9 +30,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/installation/read-me.htm
+++ b/archive/team-calendar/installation/read-me.htm
@@ -30,9 +30,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
                     ✅ New page with updated info:
-                    <a href="https://www.ssw.com.au" style="color: white">
-                        ssw.com.au
-                    </a>
+                    <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/team-calendar/userguide.html
+++ b/archive/team-calendar/userguide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/time-prosmart-tags/default.html
+++ b/archive/time-prosmart-tags/default.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>

--- a/archive/time-prosmart-tags/user-guide.html
+++ b/archive/time-prosmart-tags/user-guide.html
@@ -566,9 +566,7 @@
 <div style="color: white; font-size: 1.125rem !important; font-weight: 600;">
 <p>
      ✅ New page with updated info:
-     <a href="https://www.ssw.com.au" style="color: white">
-      ssw.com.au
-     </a>
+     <a href="https://www.ssw.com.au/products" style="color: white">ssw.com.au/products</a>
 </p>
 </div>
 </div>


### PR DESCRIPTION
### Description

As per the feedback in my last done video the archive banner for all migrated pages that mention an SSW product now point to ssw.com.au/products in the archive banner. 


The feedback was given for the done videos of the following PBIs:
https://github.com/SSWConsulting/SSW.Website/issues/2583
https://github.com/SSWConsulting/SSW.Website/issues/2583
https://github.com/SSWConsulting/SSW.Website/issues/2584