### PR TITLE
add archive banner link products web pager pages

### DIFF
--- a/archive/web-pager/default.html
+++ b/archive/web-pager/default.html
@@ -7131,7 +7131,9 @@
       >
         <p style="color: white">
           ✅ New page with updated info:
-          <a href="https://www.ssw.com.au" style="color: white"> ssw.com.au </a>
+          <a href="https://www.ssw.com.au/products" style="color: white">
+            ssw.com.au/products
+          </a>
         </p>
       </div>
     </div>
@@ -7831,8 +7833,8 @@
                       <p align="left">
                         SSW Web Pager is a utility that sends any web page to
                         your inbox. This utility has many applications - from
-                        emailing you the latest news daily to emailing  daily
-                        and monthly HTML reports to your administrator.
+                        emailing you the latest news daily to emailing&nbsp;
+                        daily and monthly HTML reports to your administrator.
                         Everything you need will be in one centralized location
                         -
                         <b> the Inbox </b>
@@ -8095,7 +8097,7 @@
           <div class="container">
             <div class="footer-text row">
               <div class="col-xs-12 col-sm-4 copyright">
-                <p>© Copyright SSW 1990-2024. All Rights Reserved.</p>
+                <p>&copy; Copyright SSW 1990-2024. All Rights Reserved.</p>
               </div>
               <div class="col-xs-12 col-sm-8 footer-links">
                 <p>

--- a/archive/web-pager/user-guide.html
+++ b/archive/web-pager/user-guide.html
@@ -7131,7 +7131,9 @@
       >
         <p style="color: white">
           ✅ New page with updated info:
-          <a href="https://www.ssw.com.au" style="color: white"> ssw.com.au </a>
+          <a href="https://www.ssw.com.au/products" style="color: white">
+            ssw.com.au/products
+          </a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
### Decscription

The web pager pages didn't contain a link to the products page on the current SSW website even though WebPager is an SSW product. This PR remedies that issue.

### Relevant Issue

#20 