### PR TITLE
Updated all pages to point to events

### DIFF
--- a/archive/events/1999-msroad-show/msbrief.htm
+++ b/archive/events/1999-msroad-show/msbrief.htm
@@ -69,7 +69,9 @@
       >
         <p>
           ✅ New page with updated info:
-          <a href="https://www.ssw.com.au" style="color: white"> ssw.com.au </a>
+          <a href="https://www.ssw.com.au/events" style="color: white">
+            ssw.com.au/events
+          </a>
         </p>
       </div>
     </div>

--- a/archive/events/2004-kenya/e.htm
+++ b/archive/events/2004-kenya/e.htm
@@ -58,7 +58,9 @@
       >
         <p style="color: white">
           ✅ New page with updated info:
-          <a href="https://www.ssw.com.au" style="color: white"> ssw.com.au </a>
+          <a href="https://www.ssw.com.au/events" style="color: white">
+            ssw.com.au/events
+          </a>
         </p>
       </div>
     </div>

--- a/archive/events/visual-studio-2010-rapid-sharepoint-development.htm
+++ b/archive/events/visual-studio-2010-rapid-sharepoint-development.htm
@@ -52,7 +52,9 @@
       >
         <p>
           ✅ New page with updated info:
-          <a href="https://www.ssw.com.au" style="color: white"> ssw.com.au </a>
+          <a href="https://www.ssw.com.au/events" style="color: white">
+            ssw.com.au/events
+          </a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
### Description 
A few of the pages under /events still had archive banners that linked to ssw.com.au instead of ssw.com.au/events. I've fixed them now:

archive/events/1999-msroad-show/msbrief.htm
archive/events/visual-studio-2010-rapid-sharepoint-development.htm
archive/events/2004-kenya/e.htm