### PR TITLE
🧑‍🎨 Moved blurbs for press releases outside of press release body

### DIFF
--- a/archive/marketing/pr/2002maraccessreporter.html
+++ b/archive/marketing/pr/2002maraccessreporter.html
@@ -7844,13 +7844,14 @@
                           </tbody>
                         </table>
                       </h2>
+                      <p>
+                        <i>
+                          New .NET application from SSW leads the way in
+                          reporting on the web
+                        </i>
+                      </p>
                       <blockquote>
-                        <p align="center">
-                          <i>
-                            New .NET application from SSW leads the way in
-                            reporting on the web
-                          </i>
-                        </p>
+
                         <p>
                           Sydney- Toyota Australia has chosen
                           Superior Software for Windows' latest .NET solution -

--- a/archive/marketing/pr/200febinvestment.html
+++ b/archive/marketing/pr/200febinvestment.html
@@ -7845,7 +7845,7 @@
                           </tbody>
                         </table>
                       </h2>
-                      <p align="center">
+                      <p>
                         <i>
                           SSW commits to the development of Microsoft .NET
                           products and services for developers and managers.


### PR DESCRIPTION
### Description 

Some of the press releases had the blurb as part of the press release body. I've moved this blurb from the body of the press released to the under the heading to make them consistent with the other pages (for real this time🤦). I've also made them left aligned as per my conversation with Betty.


### Screenshot
![image](https://github.com/SSWConsulting/SSW.Website-v1-Progress/assets/65635198/2294ade4-b40a-40da-b58b-e7c271ccffde)
