### PR TITLE
🍞 Fixed first breadcrumb link on internal standards pages

### DIFF
--- a/archive/standards-internal/-employee-test-area/adam-cogan/ssw-web.html
+++ b/archive/standards-internal/-employee-test-area/adam-cogan/ssw-web.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/adel-helal/filename.html
+++ b/archive/standards-internal/-employee-test-area/adel-helal/filename.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/allan-zhou/about-me.html
+++ b/archive/standards-internal/-employee-test-area/allan-zhou/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/alvin-shen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/alvin-shen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/andrew-weaver-2/about-me.html
+++ b/archive/standards-internal/-employee-test-area/andrew-weaver-2/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/andy-taslim/about-me.html
+++ b/archive/standards-internal/-employee-test-area/andy-taslim/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/anne-rong/about-me.html
+++ b/archive/standards-internal/-employee-test-area/anne-rong/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ashraf-moollan/about.html
+++ b/archive/standards-internal/-employee-test-area/ashraf-moollan/about.html
@@ -129,7 +129,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/bao-nguyen/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/bao-nguyen/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/bhanujit-paul/about-me.html
+++ b/archive/standards-internal/-employee-test-area/bhanujit-paul/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/bill-chen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/bill-chen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/brettanderson/aboutbrett.html
+++ b/archive/standards-internal/-employee-test-area/brettanderson/aboutbrett.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/brite-cheng/about-me.html
+++ b/archive/standards-internal/-employee-test-area/brite-cheng/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/bryan-chelliah/about-me.html
+++ b/archive/standards-internal/-employee-test-area/bryan-chelliah/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/cameron-townshend/about-me.html
+++ b/archive/standards-internal/-employee-test-area/cameron-townshend/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/camilo-zuluaga/about-me-cz.html
+++ b/archive/standards-internal/-employee-test-area/camilo-zuluaga/about-me-cz.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/chenneke-zhang/about-me.html
+++ b/archive/standards-internal/-employee-test-area/chenneke-zhang/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/christopher-clarke/about-me.html
+++ b/archive/standards-internal/-employee-test-area/christopher-clarke/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/cindy-wang/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/cindy-wang/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/clarence-dang/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/clarence-dang/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/daniel-russell/about-me-3.html
+++ b/archive/standards-internal/-employee-test-area/daniel-russell/about-me-3.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/daniel-russell/about-me.html
+++ b/archive/standards-internal/-employee-test-area/daniel-russell/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/daniel-russell/aboutme-2.html
+++ b/archive/standards-internal/-employee-test-area/daniel-russell/aboutme-2.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/david-watts/about-me.html
+++ b/archive/standards-internal/-employee-test-area/david-watts/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/dipan-saha/about-me.html
+++ b/archive/standards-internal/-employee-test-area/dipan-saha/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/doni-doni/about-me.html
+++ b/archive/standards-internal/-employee-test-area/doni-doni/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/drew-walker/filename.html
+++ b/archive/standards-internal/-employee-test-area/drew-walker/filename.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ed-brown/about-me.html
+++ b/archive/standards-internal/-employee-test-area/ed-brown/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/edison-chen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/edison-chen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/eric-fang/about-me.html
+++ b/archive/standards-internal/-employee-test-area/eric-fang/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/eric-phan/about-me.html
+++ b/archive/standards-internal/-employee-test-area/eric-phan/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/evan-lin/about-me.html
+++ b/archive/standards-internal/-employee-test-area/evan-lin/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/felix-zhang/about-me.html
+++ b/archive/standards-internal/-employee-test-area/felix-zhang/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/francis-jijo/about-me.html
+++ b/archive/standards-internal/-employee-test-area/francis-jijo/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gary-lam/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gary-lam/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gary-liu/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gary-liu/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gayathri-jaya/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gayathri-jaya/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/geoff-orr/about-me.html
+++ b/archive/standards-internal/-employee-test-area/geoff-orr/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gerard-beckerleg/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gerard-beckerleg/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/glenn-osullivan/about-me.html
+++ b/archive/standards-internal/-employee-test-area/glenn-osullivan/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gordon-hartley/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gordon-hartley/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/gracia-daniel/about-me.html
+++ b/archive/standards-internal/-employee-test-area/gracia-daniel/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/greg-mc-carthy/about-me.html
+++ b/archive/standards-internal/-employee-test-area/greg-mc-carthy/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/helen-moore/about-me.html
+++ b/archive/standards-internal/-employee-test-area/helen-moore/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ian-bennett/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/ian-bennett/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/james-zhang/about-me.html
+++ b/archive/standards-internal/-employee-test-area/james-zhang/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/jatin-valabjee/profile.html
+++ b/archive/standards-internal/-employee-test-area/jatin-valabjee/profile.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/jeff-li/about-me.html
+++ b/archive/standards-internal/-employee-test-area/jeff-li/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/joe-boedijono/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/joe-boedijono/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/joe-tang/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/joe-tang/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/john-liu/about-me.html
+++ b/archive/standards-internal/-employee-test-area/john-liu/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/jonny-trees/about-me.html
+++ b/archive/standards-internal/-employee-test-area/jonny-trees/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/judah-caplan/about-me.html
+++ b/archive/standards-internal/-employee-test-area/judah-caplan/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/julian-bueno/about-me.html
+++ b/archive/standards-internal/-employee-test-area/julian-bueno/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/lei-xu-2/about-me.html
+++ b/archive/standards-internal/-employee-test-area/lei-xu-2/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/lei-xu-2/lei-xu-induction-web-standards-test.html
+++ b/archive/standards-internal/-employee-test-area/lei-xu-2/lei-xu-induction-web-standards-test.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/luke-chou/about-me.html
+++ b/archive/standards-internal/-employee-test-area/luke-chou/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/manisha-patel/about-me.html
+++ b/archive/standards-internal/-employee-test-area/manisha-patel/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/mark-chen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/mark-chen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/marlon-marescia/about-me.html
+++ b/archive/standards-internal/-employee-test-area/marlon-marescia/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/marten-ataalla/marten-ataalla.html
+++ b/archive/standards-internal/-employee-test-area/marten-ataalla/marten-ataalla.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/martin-chafei-2/about-me.html
+++ b/archive/standards-internal/-employee-test-area/martin-chafei-2/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/marwan-chamas/about-me.html
+++ b/archive/standards-internal/-employee-test-area/marwan-chamas/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/masha-gildina/about-me.html
+++ b/archive/standards-internal/-employee-test-area/masha-gildina/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/masha-gildina/masha-gildina-about-me.html
+++ b/archive/standards-internal/-employee-test-area/masha-gildina/masha-gildina-about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/max-yao/about-me.html
+++ b/archive/standards-internal/-employee-test-area/max-yao/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/michael-mileos/about-me.html
+++ b/archive/standards-internal/-employee-test-area/michael-mileos/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/michael-salameh/about-me.html
+++ b/archive/standards-internal/-employee-test-area/michael-salameh/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/michelle-hunt/about-me.html
+++ b/archive/standards-internal/-employee-test-area/michelle-hunt/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/mohsin-ali/about-me.html
+++ b/archive/standards-internal/-employee-test-area/mohsin-ali/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/mustafa-ghulam/about-me.html
+++ b/archive/standards-internal/-employee-test-area/mustafa-ghulam/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/nasir-ali/about-me.html
+++ b/archive/standards-internal/-employee-test-area/nasir-ali/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/olivia-ngan/about-me.html
+++ b/archive/standards-internal/-employee-test-area/olivia-ngan/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/paul-stovell/about-me.html
+++ b/archive/standards-internal/-employee-test-area/paul-stovell/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/peter-gfader/about-me.html
+++ b/archive/standards-internal/-employee-test-area/peter-gfader/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/philip-olsen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/philip-olsen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/rebecca-gardiner/about-me.html
+++ b/archive/standards-internal/-employee-test-area/rebecca-gardiner/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/rebecca-liu/about-me.html
+++ b/archive/standards-internal/-employee-test-area/rebecca-liu/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ron-maman/about-me.html
+++ b/archive/standards-internal/-employee-test-area/ron-maman/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ronnie-haque/about-me.html
+++ b/archive/standards-internal/-employee-test-area/ronnie-haque/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ryan-tee/about-me.html
+++ b/archive/standards-internal/-employee-test-area/ryan-tee/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/sam-akula/about-me.html
+++ b/archive/standards-internal/-employee-test-area/sam-akula/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/scott-fletcher/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/scott-fletcher/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/scott-mc-phillips/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/scott-mc-phillips/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/serena-chen/about-me.html
+++ b/archive/standards-internal/-employee-test-area/serena-chen/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/sergey-ishutin/about-me.html
+++ b/archive/standards-internal/-employee-test-area/sergey-ishutin/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/sri-gangichettu/about-me.html
+++ b/archive/standards-internal/-employee-test-area/sri-gangichettu/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/stephen-bennett/stephen.html
+++ b/archive/standards-internal/-employee-test-area/stephen-bennett/stephen.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/sumesh-ghimire/about-me.html
+++ b/archive/standards-internal/-employee-test-area/sumesh-ghimire/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/sunitha-desaraju/about-me.html
+++ b/archive/standards-internal/-employee-test-area/sunitha-desaraju/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/susan-heins/about-me.html
+++ b/archive/standards-internal/-employee-test-area/susan-heins/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/syed-mehdi/about-me.html
+++ b/archive/standards-internal/-employee-test-area/syed-mehdi/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/terry-su/about-me.html
+++ b/archive/standards-internal/-employee-test-area/terry-su/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/tiago-araujo/about-me.html
+++ b/archive/standards-internal/-employee-test-area/tiago-araujo/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/tim-kremer/about-me.html
+++ b/archive/standards-internal/-employee-test-area/tim-kremer/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/timothy-walters/about-me.html
+++ b/archive/standards-internal/-employee-test-area/timothy-walters/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/toktam-sepehri/about-me.html
+++ b/archive/standards-internal/-employee-test-area/toktam-sepehri/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/tristan-kurniawan/about-me.html
+++ b/archive/standards-internal/-employee-test-area/tristan-kurniawan/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/ulysses-maclaren/about-me.html
+++ b/archive/standards-internal/-employee-test-area/ulysses-maclaren/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/vu-hung/about-me.html
+++ b/archive/standards-internal/-employee-test-area/vu-hung/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/website-au-to-build-test/about-me.html
+++ b/archive/standards-internal/-employee-test-area/website-au-to-build-test/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/william-yin/about-me.html
+++ b/archive/standards-internal/-employee-test-area/william-yin/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/willy-ekasalim/aboutme.html
+++ b/archive/standards-internal/-employee-test-area/willy-ekasalim/aboutme.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/wilson-wu/about-me.html
+++ b/archive/standards-internal/-employee-test-area/wilson-wu/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/-employee-test-area/zune-vien/about-me.html
+++ b/archive/standards-internal/-employee-test-area/zune-vien/about-me.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/developer-products-hosting/images/default.html
+++ b/archive/standards-internal/developer-products-hosting/images/default.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/employment/accountsassessment.html
+++ b/archive/standards-internal/employment/accountsassessment.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/employment/employmenttest.html
+++ b/archive/standards-internal/employment/employmenttest.html
@@ -134,7 +134,7 @@
         <span id="ctl00_mainContentPlaceHolder_SiteMapPath1">
           <a href="#ctl00_mainContentPlaceHolder_SiteMapPath1_SkipLink"> </a>
           <span>
-            <a href="/archive" title="Home"> Home </a>
+            <a href="/" title="home"> Home </a>
           </span>
           <span> &gt; </span>
           <span>

--- a/archive/standards-internal/employment/sharepoint-expert-questions.html
+++ b/archive/standards-internal/employment/sharepoint-expert-questions.html
@@ -134,7 +134,7 @@
         <span id="ctl00_mainContentPlaceHolder_SiteMapPath1">
           <a href="#ctl00_mainContentPlaceHolder_SiteMapPath1_SkipLink"> </a>
           <span>
-            <a href="/archive" title="Home"> Home </a>
+            <a href="/" title="home"> Home </a>
           </span>
           <span> &gt; </span>
           <span>

--- a/archive/standards-internal/images/icon-experience-collection/default.html
+++ b/archive/standards-internal/images/icon-experience-collection/default.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/default.html
+++ b/archive/standards-internal/registration/default.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/new-registration-credit-card/new-promotional-product-download-page.html
+++ b/archive/standards-internal/registration/new-registration-credit-card/new-promotional-product-download-page.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/new-registration-credit-card/new-trial-product-download-page.html
+++ b/archive/standards-internal/registration/new-registration-credit-card/new-trial-product-download-page.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/new-registration-credit-card/new-web-registration-page.html
+++ b/archive/standards-internal/registration/new-registration-credit-card/new-web-registration-page.html
@@ -140,7 +140,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/new-registration-credit-card/newl-download-product-before-purchase-page.html
+++ b/archive/standards-internal/registration/new-registration-credit-card/newl-download-product-before-purchase-page.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/new-registration-credit-card/newl-product-download-page.html
+++ b/archive/standards-internal/registration/new-registration-credit-card/newl-product-download-page.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards-internal/registration/project-plan.html
+++ b/archive/standards-internal/registration/project-plan.html
@@ -134,7 +134,7 @@
           <span id="ctl00_SiteMapPathStandardsInternal">
             <a href="#ctl00_SiteMapPathStandardsInternal_SkipLink"> </a>
             <span>
-              <a href="/archive" title="Home"> Home </a>
+              <a href="/" title="home"> Home </a>
             </span>
             <span> &gt; </span>
             <span>

--- a/archive/standards/better-software-suggestions/expression.html
+++ b/archive/standards/better-software-suggestions/expression.html
@@ -136,7 +136,7 @@
         <span id="ctl00_mainContentPlaceHolder_SiteMapPath1">
           <a href="#ctl00_mainContentPlaceHolder_SiteMapPath1_SkipLink"> </a>
           <span>
-            <a href="/archive" title="Home"> Home </a>
+            <a href="/" title="home"> Home </a>
           </span>
           <span> &gt; </span>
           <span>

--- a/archive/standards/better-software-suggestions/iis.html
+++ b/archive/standards/better-software-suggestions/iis.html
@@ -131,7 +131,7 @@
         <span id="ctl00_mainContentPlaceHolder_SiteMapPath1">
           <a href="#ctl00_mainContentPlaceHolder_SiteMapPath1_SkipLink"> </a>
           <span>
-            <a href="/archive" title="Home"> Home </a>
+            <a href="/" title="home"> Home </a>
           </span>
           <span> &gt; </span>
           <span>


### PR DESCRIPTION
### Description
The first breadcrumb link for a number of internal standards pages points to the wrong page (i.e. points to "/archive" instead of "/"). This is because I ran a separate script to fix the archive banner on these pages. I've done a simple find and replace to fix these links because all of the breadcrumb links use the same format.