### PR TITLE
⛓️‍💥 Fixed code auditor product box image links

### DIFF
--- a/archive/code-auditor/contact/default.html
+++ b/archive/code-auditor/contact/default.html
@@ -8832,7 +8832,7 @@
                       <div id="sidebar">
                         <img
                           alt="Code Auditor product box"
-                          src="https://ssw.com.au/ssw/CodeAuditor/images/productBox_CodeAuditor.gif"
+                          src="/archive/code-auditor/images/product-box-code-auditor.gif"
                         />
                         <div class="download">
                           <a

--- a/archive/code-auditor/default.html
+++ b/archive/code-auditor/default.html
@@ -8766,7 +8766,7 @@
                       <div id="sidebar">
                         <img
                           alt="CodeAuditor product box"
-                          src="https://ssw.com.au/ssw/CodeAuditor/images/productBox_CodeAuditor.gif"
+                          src="/archive/code-auditor/images/product-box-code-auditor.gif"
                           style="margin-bottom: 10px"
                         />
                         <!-- <div class="download">

--- a/archive/code-auditor/rules.html
+++ b/archive/code-auditor/rules.html
@@ -8929,7 +8929,7 @@
                             <div>
                               <br />
                               <img
-                                src="https://ssw.com.au/ssw/CodeAuditor/images/productBox_CodeAuditor.gif"
+                                src="/archive/code-auditor/images/product-box-code-auditor.gif"
                               />
                             </div>
                             <ul>


### PR DESCRIPTION
### Description

The product image boxes for CodeAuditor weren't fixed by the script so I replaced the links with archived versions of the image.

![image](https://github.com/user-attachments/assets/8b160d1a-6c3b-4a4c-ba3c-d489c1b6a4eb)
**Figure**: **Example of the broken image in production**